### PR TITLE
added functionaly of an store subscriber

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,9 +66,10 @@ export function createStore(name, state = {}, reducer=defaultReducer) {
       if (typeof callback === 'function') callback(this.state)
       if (
         typeof subscribeCallback === "function" &&
+        action.type && 
         subscribedActions.includes(action.type)
       ) {
-        subscribeCallback(action, this.state);
+        subscribeCallback(action.type, this.state);
       }
     },
     setters: []

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ export function subscribe(id, actions, callback) {
     throw 'First argument must be a string';
   if (!actions || !Array.isArray(actions))
     throw 'Second argument must be an array';
-  if (!actions || typeof callback !== 'function')
+  if (!callback || typeof callback !== 'function')
     throw 'Third argument must a function';
   const subscriberExists =  subsriberExists(id);
   if(subscriberExists)

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ let subscribeCallback = null;
 const defaultReducer = (state, payload) => payload;
 
 export function subscribe(actions, callback) {
-  if (!actions || !Array.isArray(action))
+  if (!actions || !Array.isArray(actions))
     throw "First argument must be an array";
   if (!actions || typeof callback !== "function")
     throw "Second argument must a function";
@@ -66,7 +66,7 @@ export function createStore(name, state = {}, reducer=defaultReducer) {
       if (typeof callback === 'function') callback(this.state)
       if (
         typeof subscribeCallback === "function" &&
-        subscribedActions.includes(action.action)
+        subscribedActions.includes(action.type)
       ) {
         subscribeCallback(action, this.state);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
 
 let stores = {};
-let subscribedActions = [];
-let subscribeCallback = null;
+let subscriptions = {};
 
 const defaultReducer = (state, payload) => payload;
 
@@ -11,8 +10,12 @@ export function subscribe(actions, callback) {
     throw "First argument must be an array";
   if (!actions || typeof callback !== "function")
     throw "Second argument must a function";
-  subscribedActions = actions;
-  subscribeCallback = callback;
+  actions.forEach(action => {
+    if(!subscriptions[action]){
+      subscriptions[action] = [];
+    }
+    subscriptions[action].push(callback)
+  })
 }
 
 class StoreInterface {
@@ -65,11 +68,11 @@ export function createStore(name, state = {}, reducer=defaultReducer) {
       this.setters.forEach(setter => setter(this.state));
       if (typeof callback === 'function') callback(this.state)
       if (
-        typeof subscribeCallback === "function" &&
-        action.type && 
-        subscribedActions.includes(action.type)
+        action && action.type && 
+        subscriptions
       ) {
-        subscribeCallback(action.type, this.state);
+        subscriptions[action.type]
+          .forEach(callback => callback(action.type, this.state))
       }
     },
     setters: []

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,19 @@
 import { useState, useEffect } from 'react';
 
 let stores = {};
+let subscribedActions = [];
+let subscribeCallback = null;
 
 const defaultReducer = (state, payload) => payload;
+
+export function subscribe(actions, callback) {
+  if (!actions || !Array.isArray(action))
+    throw "First argument must be an array";
+  if (!actions || typeof callback !== "function")
+    throw "Second argument must a function";
+  subscribedActions = actions;
+  subscribeCallback = callback;
+}
 
 class StoreInterface {
   constructor(name, store, useReducer) {
@@ -52,7 +63,13 @@ export function createStore(name, state = {}, reducer=defaultReducer) {
     setState(action, callback) {
       this.state = this.reducer(this.state, action);
       this.setters.forEach(setter => setter(this.state));
-	    if (typeof callback === 'function') callback(this.state)
+      if (typeof callback === 'function') callback(this.state)
+      if (
+        typeof subscribeCallback === "function" &&
+        subscribedActions.includes(action.action)
+      ) {
+        subscribeCallback(action, this.state);
+      }
     },
     setters: []
   };

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -1,4 +1,4 @@
-import { createStore, getStoreByName } from '..';
+import { createStore, getStoreByName, subscribe } from '..';
 
 describe('createStore', () => {
   it('Should create an store and return its public interface', () => {
@@ -126,4 +126,16 @@ describe('store', () => {
       expect(newState).toBe('bar');
     });
   });
+
+
+  test('subscribe call works', () => {
+  	const reducer = (state, action) => action;
+    const store = createStore('store11', 'foo', reducer);
+    store.dispatch({type:'bar'});
+    subscribe(['bar'], (action, state) => {
+      expect(state).toBe('bar');
+    })
+  });
+
+  subscribe
 });

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -1,4 +1,4 @@
-import { createStore, getStoreByName, subscribe } from '..';
+import { createStore, getStoreByName, subscribe, unsubscribe } from '..';
 
 describe('createStore', () => {
   it('Should create an store and return its public interface', () => {
@@ -127,11 +127,15 @@ describe('store', () => {
     });
   });
 
-  test('subscribe needs array as first argument' , () => {
+  test('subscribe needs string as first argument' , () => {
+    expect(() => subscribe(null, [], () => {})).toThrow()
+  });
+
+  test('subscribe needs array as second argument' , () => {
     expect(() => subscribe(null, () => {})).toThrow()
   });
 
-  test('subscribe needs function as second argument' , () => {
+  test('subscribe needs function as third argument' , () => {
     expect(() => subscribe([], null)).toThrow()
   });
 
@@ -148,11 +152,11 @@ describe('store', () => {
     };
     
     const store = createStore('store11', { count: 1 }, reducer);
-    subscribe([ 'decrement'], (action, state) => {
+    subscribe('subscribe1', [ 'decrement'], (action, state) => {
       expect(action).toBe("decrement");
       expect(state.count).toBe(0);
     })
-    subscribe(['increment'], (action, state) => {
+    subscribe('subscribe2', ['increment'], (action, state) => {
       expect(action).toBe('increment');
       expect(state.count).toBe(1);
     })
@@ -173,7 +177,7 @@ describe('store', () => {
     };
     
     const store = createStore('store12', { count: 1 }, reducer);
-    subscribe([ 'decrement', 'increment'], (action, state) => {
+    subscribe('subscribe3',[ 'decrement', 'increment'], (action, state) => {
       if(action === "decrement")
         expect(state.count).toBe(0);
       if(action === "increment")
@@ -182,9 +186,23 @@ describe('store', () => {
 
     store.dispatch({type:'decrement'});
     store.dispatch({type:'increment'});
-  
   });
 
 
+  test('Unsubscribe needs a string identifier' , () => {
+    expect(() => unsubscribe(null)).toThrow()
+  });
+
+  test('Subsribers need unique identifier', () => {
+    subscribe('subscribe4', ['decrement'], () => {});
+    expect(() => subscribe('subscribe1', [], (action, state) => {})).toThrow();
+  });
+
+  test('Unsubscribe to certain subscriber', () => {
+    subscribe('subscribe5', ['decrement'], () => {});
+    expect(() => subscribe('subscribe1', [], (action, state) => {})).toThrow();
+    unsubscribe('subscribe5');
+    subscribe('subscribe5', [], () => {});
+  });
 
 });

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -127,12 +127,20 @@ describe('store', () => {
     });
   });
 
-  test('subscribe call works', () => {
+  test('subscribe needs array as first argument' , () => {
+    expect(() => subscribe(null, () => {})).toThrow()
+  });
+
+  test('subscribe needs function as second argument' , () => {
+    expect(() => subscribe([], null)).toThrow()
+  });
+
+  test('subscribe callback works for individual subscribes', () => {
   	const reducer = (state, action) => {
       switch (action.type) {
-        case "increment":
+        case 'increment':
           return { ...state, count: state.count + 1 };
-        case "decrement":
+        case 'decrement':
           return { ...state, count: state.count -1 };
         default:
           return state;
@@ -145,9 +153,33 @@ describe('store', () => {
       expect(state.count).toBe(0);
     })
     subscribe(['increment'], (action, state) => {
-      expect(action).toBe("increment");
+      expect(action).toBe('increment');
       expect(state.count).toBe(1);
     })
+    store.dispatch({type:'decrement'});
+    store.dispatch({type:'increment'});
+  });
+
+  test('subscribe callback works with multiple actions at once', () => {
+  	const reducer = (state, action) => {
+      switch (action.type) {
+        case 'increment':
+          return { ...state, count: state.count + 1 };
+        case 'decrement':
+          return { ...state, count: state.count -1 };
+        default:
+          return state;
+      }
+    };
+    
+    const store = createStore('store12', { count: 1 }, reducer);
+    subscribe([ 'decrement', 'increment'], (action, state) => {
+      if(action === "decrement")
+        expect(state.count).toBe(0);
+      if(action === "increment")
+        expect(state.count).toBe(1);
+    })
+
     store.dispatch({type:'decrement'});
     store.dispatch({type:'increment'});
   

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -132,11 +132,11 @@ describe('store', () => {
   });
 
   test('subscribe needs array as second argument' , () => {
-    expect(() => subscribe(null, () => {})).toThrow()
+    expect(() => subscribe("subscribe1", null, () => {})).toThrow()
   });
 
   test('subscribe needs function as third argument' , () => {
-    expect(() => subscribe([], null)).toThrow()
+    expect(() => subscribe("subscribe2", [], null)).toThrow()
   });
 
   test('subscribe callback works for individual subscribes', () => {
@@ -152,11 +152,11 @@ describe('store', () => {
     };
     
     const store = createStore('store11', { count: 1 }, reducer);
-    subscribe('subscribe1', [ 'decrement'], (action, state) => {
+    subscribe('subscribe3', [ 'decrement'], (action, state) => {
       expect(action).toBe("decrement");
       expect(state.count).toBe(0);
     })
-    subscribe('subscribe2', ['increment'], (action, state) => {
+    subscribe('subscribe4', ['increment'], (action, state) => {
       expect(action).toBe('increment');
       expect(state.count).toBe(1);
     })
@@ -177,7 +177,7 @@ describe('store', () => {
     };
     
     const store = createStore('store12', { count: 1 }, reducer);
-    subscribe('subscribe3',[ 'decrement', 'increment'], (action, state) => {
+    subscribe('subscribe5',[ 'decrement', 'increment'], (action, state) => {
       if(action === "decrement")
         expect(state.count).toBe(0);
       if(action === "increment")
@@ -194,15 +194,15 @@ describe('store', () => {
   });
 
   test('Subsribers need unique identifier', () => {
-    subscribe('subscribe4', ['decrement'], () => {});
-    expect(() => subscribe('subscribe1', [], (action, state) => {})).toThrow();
+    subscribe('subscribe6', ['decrement'], () => {});
+    expect(() => subscribe('subscribe6', [], (action, state) => {})).toThrow();
   });
 
   test('Unsubscribe to certain subscriber', () => {
-    subscribe('subscribe5', ['decrement'], () => {});
-    expect(() => subscribe('subscribe1', [], (action, state) => {})).toThrow();
-    unsubscribe('subscribe5');
-    subscribe('subscribe5', [], () => {});
+    subscribe('subscribe7', ['decrement'], () => {});
+    expect(() => subscribe('subscribe7', [], (action, state) => {})).toThrow();
+    unsubscribe('subscribe7');
+    subscribe('subscribe7', [], () => {});
   });
 
 });

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -5,12 +5,12 @@ describe('createStore', () => {
     const store = createStore('store1', 0);
     expect(store.getState()).toBe(0);
     expect(store.name).toBe('store1');
-    expect(Object.keys(store)).toEqual(['name', 'setState', 'getState']);
+    expect(Object.keys(store)).toEqual(['name', 'setState', 'getState', 'subscribe', 'unsubscribe']);
 
     const store2 = createStore('store2', 0, (state, action) => action.payload);
     expect(store2.getState()).toBe(0);
     expect(store2.name).toBe('store2');
-    expect(Object.keys(store2)).toEqual(['name', 'dispatch', 'getState']);
+    expect(Object.keys(store2)).toEqual(['name', 'dispatch', 'getState', 'subscribe', 'unsubscribe']);
   });
 
   it('Should not allow stores with the same name to be created', () => {
@@ -33,7 +33,7 @@ describe('getStoreByName', () => {
     createStore('test');
 
     const store = getStoreByName('test');
-    expect(Object.keys(store)).toEqual(['name', 'setState', 'getState']);
+    expect(Object.keys(store)).toEqual(['name', 'setState', 'getState', 'subscribe', 'unsubscribe']);
     expect(store.name).toBe('test');
   })
 
@@ -125,84 +125,6 @@ describe('store', () => {
     store.dispatch('bar', (newState) => {
       expect(newState).toBe('bar');
     });
-  });
-
-  test('subscribe needs string as first argument' , () => {
-    expect(() => subscribe(null, [], () => {})).toThrow()
-  });
-
-  test('subscribe needs array as second argument' , () => {
-    expect(() => subscribe("subscribe1", null, () => {})).toThrow()
-  });
-
-  test('subscribe needs function as third argument' , () => {
-    expect(() => subscribe("subscribe2", [], null)).toThrow()
-  });
-
-  test('subscribe callback works for individual subscribes', () => {
-  	const reducer = (state, action) => {
-      switch (action.type) {
-        case 'increment':
-          return { ...state, count: state.count + 1 };
-        case 'decrement':
-          return { ...state, count: state.count -1 };
-        default:
-          return state;
-      }
-    };
-    
-    const store = createStore('store11', { count: 1 }, reducer);
-    subscribe('subscribe3', [ 'decrement'], (action, state) => {
-      expect(action).toBe("decrement");
-      expect(state.count).toBe(0);
-    })
-    subscribe('subscribe4', ['increment'], (action, state) => {
-      expect(action).toBe('increment');
-      expect(state.count).toBe(1);
-    })
-    store.dispatch({type:'decrement'});
-    store.dispatch({type:'increment'});
-  });
-
-  test('subscribe callback works with multiple actions at once', () => {
-  	const reducer = (state, action) => {
-      switch (action.type) {
-        case 'increment':
-          return { ...state, count: state.count + 1 };
-        case 'decrement':
-          return { ...state, count: state.count -1 };
-        default:
-          return state;
-      }
-    };
-    
-    const store = createStore('store12', { count: 1 }, reducer);
-    subscribe('subscribe5',[ 'decrement', 'increment'], (action, state) => {
-      if(action === "decrement")
-        expect(state.count).toBe(0);
-      if(action === "increment")
-        expect(state.count).toBe(1);
-    })
-
-    store.dispatch({type:'decrement'});
-    store.dispatch({type:'increment'});
-  });
-
-
-  test('Unsubscribe needs a string identifier' , () => {
-    expect(() => unsubscribe(null)).toThrow()
-  });
-
-  test('Subsribers need unique identifier', () => {
-    subscribe('subscribe6', ['decrement'], () => {});
-    expect(() => subscribe('subscribe6', [], (action, state) => {})).toThrow();
-  });
-
-  test('Unsubscribe to certain subscriber', () => {
-    subscribe('subscribe7', ['decrement'], () => {});
-    expect(() => subscribe('subscribe7', [], (action, state) => {})).toThrow();
-    unsubscribe('subscribe7');
-    subscribe('subscribe7', [], () => {});
   });
 
 });

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -127,15 +127,32 @@ describe('store', () => {
     });
   });
 
-
   test('subscribe call works', () => {
-  	const reducer = (state, action) => action;
-    const store = createStore('store11', 'foo', reducer);
-    store.dispatch({type:'bar'});
-    subscribe(['bar'], (action, state) => {
-      expect(state).toBe('bar');
+  	const reducer = (state, action) => {
+      switch (action.type) {
+        case "increment":
+          return { ...state, count: state.count + 1 };
+        case "decrement":
+          return { ...state, count: state.count -1 };
+        default:
+          return state;
+      }
+    };
+    
+    const store = createStore('store11', { count: 1 }, reducer);
+    subscribe([ 'decrement'], (action, state) => {
+      expect(action).toBe("decrement");
+      expect(state.count).toBe(0);
     })
+    subscribe(['increment'], (action, state) => {
+      expect(action).toBe("increment");
+      expect(state.count).toBe(1);
+    })
+    store.dispatch({type:'decrement'});
+    store.dispatch({type:'increment'});
+  
   });
 
-  subscribe
+
+
 });

--- a/src/tests/subscribe.test.js
+++ b/src/tests/subscribe.test.js
@@ -63,6 +63,13 @@ describe('subscribe', () => {
     store1.subscribe([], () => {});
   });
 
+  test('can unsubscribe to specific store', () => {
+    store1.subscribe(['decrement'], (action, state) => {});
+    store2.subscribe(['decrement'], (action, state) => {});
+    store1.unsubscribe();
+    store1.subscribe(['decrement'], (action, state) => {});
+  });
+
   test('subscribe callback works with multiple actions', () => {
     store1.subscribe([ 'decrement', 'increment'], (action, state) => {
       if(action === "decrement")

--- a/src/tests/subscribe.test.js
+++ b/src/tests/subscribe.test.js
@@ -1,0 +1,91 @@
+import { createStore } from '..';
+
+describe('subscribe', () => {
+
+  const reducer = (state, action) => {
+    switch (action.type) {
+        case 'increment':
+            return { ...state, count: state.count + 1 };
+        case 'decrement':
+            return { ...state, count: state.count -1 };
+        case 'reset':
+            return { ...state, count: 1 };
+        default:
+        return state;
+    }
+  };
+  const reducer2 = (state, action) => {
+    switch (action.type) {
+        case 'increment':
+            return { ...state, count: state.count + 1 };
+        case 'decrement':
+            return { ...state, count: state.count -1 };
+        case 'reset':
+            return { ...state, count: 1 };
+        default:
+        return state;
+    }
+  };
+  let store1 = createStore('store1', { count: 1 }, reducer);
+  let store2 = createStore('store2', { count: 1 }, reducer2);
+
+  afterEach(() => {
+    store1.unsubscribe();
+    store2.unsubscribe();
+    store1.dispatch({type:'reset'});
+    store2.dispatch({type:'reset'});
+  })
+  
+  test('subscribe needs array as first argument' , () => {
+    expect(() => store1.subscribe(null, () => {})).toThrow()
+  });
+
+  test('subscribe needs function as second argument' , () => {
+    expect(() => store1.subscribe([], null)).toThrow()
+  });
+
+  test('subscribe callback works', () => {
+    store1.subscribe(['decrement'], (action, state) => {
+      expect(action.type).toBe("decrement");
+      expect(state.count).toBe(0);
+    });
+    store1.dispatch({type:'decrement'});
+  });
+
+  test('cant update active subscription', () => {
+    store1.subscribe(['decrement'], (action, state) => {});
+    expect(() => store1.subscribe(['increment'], () => {})).toThrow();
+  });
+  
+  test('unsubscribe works', () => {
+    store1.subscribe(['decrement'], (action, state) => {});
+    store1.unsubscribe();
+    store1.subscribe([], () => {});
+  });
+
+  test('subscribe callback works with multiple actions', () => {
+    store1.subscribe([ 'decrement', 'increment'], (action, state) => {
+      if(action === "decrement")
+        expect(state.count).toBe(0);
+      if(action === "increment")
+        expect(state.count).toBe(1);
+    })
+
+    store1.dispatch({type:'decrement'});
+    store1.dispatch({type:'increment'});
+  });
+
+  test('multiple subscriptions works without interfering', () => {
+    store1.subscribe(['decrement'], (action, state) => { 
+        expect(action.type).toBe('decrement');
+        expect(state.count).toBe(0);
+    });
+    store2.subscribe(['increment'], (action, state) => {
+         expect(action.type).toBe('increment');
+         expect(state.count).toBe(2);
+    });
+    store1.dispatch({type:'decrement'});
+    store2.dispatch({type:'increment'});
+  });
+
+});


### PR DESCRIPTION
I have an example of feature i would like to add.
A cross store subscriber functionality would be really handy when one wants to execute certain logic depending on state changes.

For example, in my app i want an AsyncStorage module to store certain values on update, a hook like this certainly makes the it user friendly.

Please come with feedback and improvement suggestions!