### PR TITLE
Add TypeScript typings file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1096,22 +1096,6 @@
       "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
       "dev": true
     },
-    "@types/prop-types": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.0.tgz",
-      "integrity": "sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==",
-      "dev": true
-    },
-    "@types/react": {
-      "version": "16.8.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.12.tgz",
-      "integrity": "sha512-MZZiv11BQhsxFp5DHDmRKBi6Nv3jwOhRiFFDE7ZJ1+rb52gdOd9y/qY0+5wyV/PQVK9926wFMjpQj3BJ18pb4Q==",
-      "dev": true,
-      "requires": {
-        "@types/prop-types": "*",
-        "csstype": "^2.2.0"
-      }
-    },
     "@webassemblyjs/ast": {
       "version": "1.7.10",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.10.tgz",
@@ -2814,12 +2798,6 @@
       "requires": {
         "cssom": "0.3.x"
       }
-    },
-    "csstype": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
-      "integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg==",
-      "dev": true
     },
     "cyclist": {
       "version": "0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1096,6 +1096,22 @@
       "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.0.tgz",
+      "integrity": "sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.8.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.12.tgz",
+      "integrity": "sha512-MZZiv11BQhsxFp5DHDmRKBi6Nv3jwOhRiFFDE7ZJ1+rb52gdOd9y/qY0+5wyV/PQVK9926wFMjpQj3BJ18pb4Q==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.7.10",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.10.tgz",
@@ -2799,6 +2815,12 @@
         "cssom": "0.3.x"
       }
     },
+    "csstype": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
+      "integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg==",
+      "dev": true
+    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -3939,7 +3961,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3960,12 +3983,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3980,17 +4005,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4107,7 +4135,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4119,6 +4148,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4133,6 +4163,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4140,12 +4171,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4164,6 +4197,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4244,7 +4278,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4256,6 +4291,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4341,7 +4377,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4377,6 +4414,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4396,6 +4434,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4439,12 +4478,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9798,6 +9839,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.1.tgz",
+      "integrity": "sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==",
       "dev": true
     },
     "uglify-es": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "dist/react-hookstore.js",
   "module": "src/index.js",
   "jsnext:main": "src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "test": "jest",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls",
-    "build": "webpack --progress --config webpack.prod.config.js",
+    "build": "tsc && webpack --progress --config webpack.prod.config.js",
     "start": "webpack-dev-server --hot --reload --config webpack.dev.config.js"
   },
   "repository": {
@@ -42,6 +43,7 @@
     "@babel/preset-env": "^7.2.3",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-stage-0": "^7.0.0",
+    "@types/react": "^16.8.12",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.4",
@@ -53,6 +55,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "regenerator-runtime": "^0.13.1",
+    "typescript": "^3.4.1",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.10",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@babel/preset-env": "^7.2.3",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-stage-0": "^7.0.0",
-    "@types/react": "^16.8.12",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.4",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,38 +1,43 @@
-import * as React from "react";
 
-type ReducerType<TState> = (state: TState, payload: any) => TState;
+declare module 'react-hookstore' {
+    type StateCallback<TState> = (state: TState) => void;
 
-type SetStateType<TState> = (state: TState, callback: React.Dispatch<TState>) => void;
+    type ReducerType<TState> = (state: TState, payload: any) => TState;
 
-type DispatchType<TState, TPayload = any> = (payload: TPayload, callback: React.Dispatch<TState>) => void;
+    type SetStateType<TState> = (state: TState, callback?: StateCallback<TState>) => void;
 
-type StoreStateHookType<TState> = [ TState, SetStateType<TState> ];
+    type DispatchType<TState, TPayload = any> = (payload: TPayload, callback?: StateCallback<TState>) => void;
 
-type StoreDispatchHookType<TState, TPayload> = [ TState, DispatchType<TState, TPayload> ];
+    type StoreStateHookType<TState> = [TState, SetStateType<TState>];
 
-declare const defaultReducer: ReducerType<any>;
+    type StoreDispatchHookType<TState> = [TState, DispatchType<TState>];
 
-declare interface StoreSpec<TState> {
-    state: TState;
-    reducer: ReducerType<TState>;
-    setState: SetStateType<TState> | DispatchType<TState>;
-    setters: React.Dispatch<TState>[]
+    const defaultReducer: ReducerType<any>;
+
+    export interface StoreSpec<TState> {
+        state: TState;
+        reducer: ReducerType<TState>;
+        setState: SetStateType<TState> | DispatchType<TState>;
+        setters: StateCallback<TState>[]
+    }
+
+    export interface StateStoreInterface<TState> {
+        setState(state: TState, callback?: StateCallback<TState>): void;
+    }
+
+    export interface ReducerStoreInterface<TState> {
+        dispatch<TPayload>(payload: TPayload, callback?: StateCallback<TState>): void;
+    }
+
+    export function createStore<TState>(name: string, state: TState): StateStoreInterface<TState>;
+
+    export function createStore<TState>(name: string, state: TState, reducer: ReducerType<TState>): ReducerStoreInterface<TState>;
+
+    export function getStoreByName<TState>(name: string): StateStoreInterface<TState> | ReducerStoreInterface<TState>;
+
+    export function useStore<TState>(identifier: string): StoreStateHookType<TState> | StoreDispatchHookType<TState>;
+
+    export function useStore<TState>(store: StateStoreInterface<TState>): StoreStateHookType<TState>;
+
+    export function useStore<TState>(store: ReducerStoreInterface<TState>): StoreDispatchHookType<TState>;
 }
-
-declare class StoreInterface<TState> {
-    constructor(name: string, store: StoreSpec<TState>, useReducer: boolean);
-    setState(state: TState, callback?: React.Dispatch<TState>): void;
-    dispatch(payload: any, callback?: React.Dispatch<TState>): void;    
-}
-
-declare function createStore<TState>(name: string, state?: TState, reducer?: ReducerType<TState>): StoreInterface<TState>;
-
-declare function getStoreByName<TState>(name: string): StoreInterface<TState>; 
-
-declare function useStore<TState, TPayload>(identifier: string): StoreDispatchHookType<TState, TPayload>;
-
-declare function useStore<TState>(identifier: string): StoreStateHookType<TState>;
-
-declare function useStore<TState, TPayload>(store: StoreInterface<TState>): StoreDispatchHookType<TState, TPayload>;
-
-declare function useStore<TState>(store: StoreInterface<TState>): StoreStateHookType<TState>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+type ReducerType<TState> = (state: TState, payload: any) => TState;
+
+type SetStateType<TState> = (state: TState, callback: React.Dispatch<TState>) => void;
+
+type DispatchType<TState, TPayload = any> = (payload: TPayload, callback: React.Dispatch<TState>) => void;
+
+type StoreStateHookType<TState> = [ TState, SetStateType<TState> ];
+
+type StoreDispatchHookType<TState, TPayload> = [ TState, DispatchType<TState, TPayload> ];
+
+declare const defaultReducer: ReducerType<any>;
+
+declare interface StoreSpec<TState> {
+    state: TState;
+    reducer: ReducerType<TState>;
+    setState: SetStateType<TState> | DispatchType<TState>;
+    setters: React.Dispatch<TState>[]
+}
+
+declare class StoreInterface<TState> {
+    constructor(name: string, store: StoreSpec<TState>, useReducer: boolean);
+    setState(state: TState, callback?: React.Dispatch<TState>): void;
+    dispatch(payload: any, callback?: React.Dispatch<TState>): void;    
+}
+
+declare function createStore<TState>(name: string, state?: TState, reducer?: ReducerType<TState>): StoreInterface<TState>;
+
+declare function getStoreByName<TState>(name: string): StoreInterface<TState>; 
+
+declare function useStore<TState, TPayload>(identifier: string): StoreDispatchHookType<TState, TPayload>;
+
+declare function useStore<TState>(identifier: string): StoreStateHookType<TState>;
+
+declare function useStore<TState, TPayload>(store: StoreInterface<TState>): StoreDispatchHookType<TState, TPayload>;
+
+declare function useStore<TState>(store: StoreInterface<TState>): StoreStateHookType<TState>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "files": [ "src/index.d.ts" ],
+    "compilerOptions": {
+        "noImplicitAny": true,
+        "strict": true
+    }
+}


### PR DESCRIPTION
Resolves #19 

Adds a TypeScript typings file for TypeScript support. Note that I have not fully tested this yet, so for now it's a draft PR to get feedback. In particular, I'd like feedback on the reducer/dispatch types, as I'm not confident in that.