### PR TITLE
simplify subscription system, adds examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Try it on [Codesandbox!](https://codesandbox.io/s/r58pqonkop)
   - [getStoreByName](#api_getStoreByName)
   - [StoreInterface](#api_storeInterface)
   - [useStore](#api_useStore)
-  - [useStore](#api_useStore)
 - [Migrating from v1.0 to v1.1](#migration)
 
 > ⚠️ BREAKING CHANGES: in version 1.4+, `store.subscribe` was simplified. check the [Store Interface API](#api_storeInterface)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ function TodoList() {
 
 export { TodoList, AddTodo };
 ```
+### More examples
+Check out the [Codesandbox demo!](https://codesandbox.io/s/r58pqonkop)
+
 ## Methods API
 ### <a name="api_createStore">`createStore(name:String, state?:*, reducer?:Function):StoreInterface`</a>
 Creates a store to be used across the entire application. Returns a StoreInterface object.

--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ The store's initial state. it can be any data type. defaults to an empty object.
 You can specify a reducer function to take care of state changes. the reducer functions receives two arguments, the previous state and the action that triggered the state update. the function must return a new state, if not, the new state will be `null`. Optional
 
 ### <a name="api_getStoreByName">`getStoreByName(name:String):StoreInterface`</a>
-Finds a store by its name and return its instance.
+Finds a store by its name and returns its instance.
 ### Arguments
-#### `name:String
+#### `name:String`
 The name of the store.
 
 ## Objects API
@@ -194,11 +194,11 @@ The name of the store;
 #### `getState:Function():*`
 A method that returns the store's current state
 #### `setState:Function(state:*, callback?:Function)`
-Sets the state of the store. works if the store does not use a reducer state handler. Otherwise, use `dispatch`. callback is optional and will receive new state as argument
+Sets the state of the store. works if the store does not use a reducer state handler. Otherwise, use `dispatch`. callback is optional and will be invoked once the state is updated, receiving the updated state as argument.
 #### `dispatch:Function(action:*, callback?:Function)`
-Dispatchs whatever is passed into this function to the store. works if the store uses a reducer state handler. Otherwise, use `setState`. callback is optional and will receive new state as argument
+Dispatches whatever is passed into this function to the store. works if the store uses a reducer state handler. Otherwise, use `setState`. callback is optional and will be invoked once the state is updated, receiving the updated state as argument.
 #### `subscribe:Function(callback:Function):unsubscribe:Function`
-subscribe a function to be called everytime a state changes. If the store is reducer-based, the callback function will be called with `action` as the first argument and `state` as the second. otherwise, it'll be called with `state` as the only argument.
+The callback function will be invoked everytime the store state changes. If the store is reducer-based, the callback function will be called with `action` as the first argument and `state` as the second. otherwise, it'll be called with `state` as the only argument.
 
 the subscribe method returns a function that can be called in order to cancel the subscription for the callback function.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Try it on [Codesandbox!](https://codesandbox.io/s/r58pqonkop)
   - [Basic](#usage_basic)
   - [Referencing stores](#usage_namespace)
   - [Reducer powered stores](#usage_reducer)
+  - [More examples](https://codesandbox.io/s/r58pqonkop)
 - API
   - [createStore](#api_createStore)
   - [getStoreByName](#api_getStoreByName)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Try it on [Codesandbox!](https://codesandbox.io/s/r58pqonkop)
 - [Installation](#installation)
 - Usage
   - [Basic](#usage_basic)
-  - [Namespacing and referencing stores](#usage_namespace)
+  - [Referencing stores](#usage_namespace)
   - [Reducer powered stores](#usage_reducer)
 - API
   - [createStore](#api_createStore)
@@ -64,7 +64,7 @@ function AnotherComponent() {
 }
 ```
 
-### <a name="usage_namespace">Namespacing and referencing stores</a>
+### <a name="usage_namespace">Referencing stores</a>
 It is possible to create multiple stores in an app.
 Stores can be referenced by using their instance that is returned by the createStore method, as well as using their name.
 
@@ -109,7 +109,7 @@ const todoListStore = createStore(
     todos: [{ id: 0, text: 'buy milk' }]
   },
   (state, action) => {
-    // when a reducer is being used, you must return a new state object
+    // when a reducer is being used, you must return a new state value
     switch (action.type) {
       case 'add':
         const id = ++state.idCount;
@@ -123,34 +123,25 @@ const todoListStore = createStore(
           todos: state.todos.filter(todo => todo.id !== action.payload)
         };
       default:
-        return {
-          ...state,
-          todos: [...state.todos]
-        };
+        return state;
     }
   }
 );
 
 function AddTodo() {
   const [state, dispatch] = useStore('todoList');
-  // Let's ref the input to make it disabled while submit is being handled
-  const input = React.useRef(null);
+  const inputRef = React.useRef(null);
 
   const onSubmit = e => {
     e.preventDefault();
-    const todo = input.current.value;
-    input.current.value = '';
-    dispatch({ type: 'add', payload: todo }, todoCreated);
-  };
-
-  const todoCreated = newState => {
-    input.current.disabled = false;
-    input.current.value = '';
+    const todo = inputRef.current.value;
+    inputRef.current.value = '';
+    dispatch({ type: 'add', payload: todo });
   };
 
   return (
     <form onSubmit={onSubmit}>
-      <input ref={input} />
+      <input ref={inputRef} />
       <button>Create TODO</button>
     </form>
   );
@@ -177,7 +168,7 @@ function TodoList() {
 export { TodoList, AddTodo };
 ```
 ## Methods API
-### <a name="api_createStore">`createStore(name:String, state:*, reducer:Function):StoreInterface`</a>
+### <a name="api_createStore">`createStore(name:String, state?:*, reducer?:Function):StoreInterface`</a>
 Creates a store to be used across the entire application. Returns a StoreInterface object.
 ### Arguments
 #### `name:String`
@@ -201,10 +192,14 @@ The store instance that is returned by the createStore and getStoreByName method
 The name of the store;
 #### `getState:Function():*`
 A method that returns the store's current state
-#### `setState:Function(state:*, callback:Function)`
+#### `setState:Function(state:*, callback?:Function)`
 Sets the state of the store. works if the store does not use a reducer state handler. Otherwise, use `dispatch`. callback is optional and will receive new state as argument
-#### `dispatch:Function(action:*, callback:Function)`
+#### `dispatch:Function(action:*, callback?:Function)`
 Dispatchs whatever is passed into this function to the store. works if the store uses a reducer state handler. Otherwise, use `setState`. callback is optional and will receive new state as argument
+#### `subscribe:Function(callback:Function):unsubscribe:Function`
+subscribe a function to be called everytime a state changes. If the store is reducer-based, the callback function will be called with `action` as the first argument and `state` as the second. otherwise, it'll be called with `state` as the only argument.
+
+the subscribe method returns a function that can be called in order to cancel the subscription for the callback function.
 
 ## React API
 ### <a name="api_useStore">`useStore(identifier:String|StoreInterface):Array[state, setState|dispatch]`</a>

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Try it on [Codesandbox!](https://codesandbox.io/s/r58pqonkop)
   - [getStoreByName](#api_getStoreByName)
   - [StoreInterface](#api_storeInterface)
   - [useStore](#api_useStore)
+  - [useStore](#api_useStore)
 - [Migrating from v1.0 to v1.1](#migration)
 
-> ⚠️ BREAKING CHANGES: Version 1.1 is not compatible with previous versions. It is easy to update your previous versions' code to work with it, though. [Click here](#migration) to know how.
+> ⚠️ BREAKING CHANGES: in version 1.4+, `store.subscribe` was simplified. check the [Store Interface API](#api_storeInterface)
 
 ## <a name="installation">Installation</a>
 You can install the lib through NPM or grab the files in the `dist` folder of this repository.

--- a/example/index.js
+++ b/example/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { StatefulHello, AnotherComponent } from './basic';
 import { AddTodo, TodoList } from './reducers';
+import SubscriptionExample from './subscribe';
 
 document.addEventListener('DOMContentLoaded', function() {
   ReactDOM.render(
@@ -10,10 +11,15 @@ document.addEventListener('DOMContentLoaded', function() {
       <p>A simple store without reducer logic</p>
       <StatefulHello />
       <AnotherComponent />
+      <hr/>
       <h1>Advanced example</h1>
-      <p>A namespace and reducer-powered store, using callback</p>
+      <p>A reducer-powered store</p>
       <AddTodo />
       <TodoList />
+      <hr/>
+      <h1>Subscribe example</h1>
+      <p>Get notified when the state changes!</p>
+      <SubscriptionExample />
     </React.Fragment>,
     document.querySelector('#app')
   );

--- a/example/reducers.js
+++ b/example/reducers.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { createStore, useStore } from '../src';
 
 // this one is more complex, it has a name and a reducer function
@@ -33,25 +33,18 @@ createStore(
 
 export function AddTodo() {
   const [ state, dispatch ] = useStore('todoList');
-  let input;
-  
+  const inputRef = useRef(null);
+
   const onSubmit = (e) => {
     e.preventDefault();
-    input = e.target.querySelector('input');
-    const todo = input.value;
-    input.value = '.............';
-    input.disabled = true;
-    dispatch({ type: 'create', payload: todo },todoCreated);
+    const todo = inputRef.current.value;
+    inputRef.current.value = '';
+    dispatch({ type: 'create', payload: todo });
   }
 
-  const todoCreated=(newState)=>{
-	input.disabled = false;
-	input.value = '';
-  }
-  
   return (
     <form onSubmit={onSubmit}>
-      <input></input>
+      <input ref={inputRef}></input>
       <button>Create TODO</button>
     </form>
   )

--- a/example/subscribe.js
+++ b/example/subscribe.js
@@ -11,7 +11,7 @@ const store = createStore('clickCounter2', 0);
 const unsubscribe = store.subscribe((state) => {
   alert('You increased the counter!');
   if (state >= 3) {
-    //after three executions, let's unsubscribe to get rid of the alert!
+    //after three executions, lets unsubscribe to get rid of the alert!
     unsubscribe();
   }
 })

--- a/example/subscribe.js
+++ b/example/subscribe.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { createStore, useStore } from '../src';
+
+const defaultStyles = {
+  padding: 10, backgroundColor: 'turquoise', marginTop: 10, color: 'black'
+}
+
+const store = createStore('clickCounter2', 0);
+
+// this will execute everytime the state is updated
+const unsubscribe = store.subscribe((state) => {
+  alert('You increased the counter!');
+  if (state >= 3) {
+    //after three executions, let's unsubscribe to get rid of the alert!
+    unsubscribe();
+  }
+})
+
+export default function SubscriptionExample() {
+  const [ state, setState ] = useStore(store);
+
+  return (
+    <div style={{ ...defaultStyles }}>
+      <h1>Hello, component!</h1>
+      <h2>The button inside this component was clicked {state} times</h2>
+      <p> After 3 clicks, you won't receive anymore alerts! </p>
+      <button type="button" onClick={() => setState(state+1)}>Update</button>
+    </div>
+  );
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export function createStore(name, state = {}, reducer=defaultReducer) {
       this.state = this.reducer(this.state, action);
       this.setters.forEach(setter => setter(this.state));
       if (subscriptions[name].length) {
-        subscriptions[name].forEach(c => c(action, this.state));
+        subscriptions[name].forEach(c => c(this.state, action));
       }
       if (typeof callback === 'function') callback(this.state)
     },

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ let subscriptions = {};
 
 const defaultReducer = (state, payload) => payload;
 
+/** The public interface of a store */
 class StoreInterface {
   constructor(name, store, useReducer) {
     this.name = name;
@@ -14,6 +15,16 @@ class StoreInterface {
     this.subscribe = this.subscribe.bind(this);
   }
 
+  /**
+   * Subscribe to store changes
+   * @callback callback - The function to be invoked everytime the store is updated
+   * @return {Number} The x value.
+   */
+
+  /**
+  *
+  * @param {callback} state, action
+  */
   subscribe(callback) {
     if (!callback || typeof callback !== 'function') {
       throw `store.subscribe callback argument must be a function. got '${typeof callback}' instead.`;
@@ -85,9 +96,10 @@ export function createStore(name, state = {}, reducer=defaultReducer) {
 
 /**
  * Returns a store instance based on its name
- * @param {String} name - The name of the wanted store
+ * @callback {String} name - The name of the wanted store
  * @returns {StoreInterface} the store instance
  */
+
 export function getStoreByName(name) {
   try {
     return stores[name].public;

--- a/src/tests/store.test.js
+++ b/src/tests/store.test.js
@@ -5,12 +5,12 @@ describe('createStore', () => {
     const store = createStore('store1', 0);
     expect(store.getState()).toBe(0);
     expect(store.name).toBe('store1');
-    expect(Object.keys(store)).toEqual(['name', 'setState', 'getState', 'subscribe', 'unsubscribe']);
+    expect(Object.keys(store)).toEqual(['name', 'setState', 'getState', 'subscribe']);
 
     const store2 = createStore('store2', 0, (state, action) => action.payload);
     expect(store2.getState()).toBe(0);
     expect(store2.name).toBe('store2');
-    expect(Object.keys(store2)).toEqual(['name', 'dispatch', 'getState', 'subscribe', 'unsubscribe']);
+    expect(Object.keys(store2)).toEqual(['name', 'dispatch', 'getState', 'subscribe']);
   });
 
   it('Should not allow stores with the same name to be created', () => {
@@ -33,7 +33,7 @@ describe('getStoreByName', () => {
     createStore('test');
 
     const store = getStoreByName('test');
-    expect(Object.keys(store)).toEqual(['name', 'setState', 'getState', 'subscribe', 'unsubscribe']);
+    expect(Object.keys(store)).toEqual(['name', 'setState', 'getState', 'subscribe']);
     expect(store.name).toBe('test');
   })
 

--- a/src/tests/subscribe.test.js
+++ b/src/tests/subscribe.test.js
@@ -20,7 +20,7 @@ describe('store.subscribe', () => {
     const subscriber = jest.fn();
     store.subscribe(subscriber);
     store.dispatch({ type: 'test', payload: 1 });
-    expect(subscriber).toHaveBeenCalledWith({ type: 'test', payload: 1 }, 1);
+    expect(subscriber).toHaveBeenCalledWith(1, { type: 'test', payload: 1 });
   });
 
   test('cant resubscribe with the same function', () => {


### PR DESCRIPTION
current subscription system is great, but it does not fit with the theme of the library, IMO. After some personal usage and getting opinions from other devs and even a professional team that is using the lib, we came into the agreement that the library should keep providing `foundational` functionality that enables many use cases and implementations, so keeping it simple is the goal.

This refactors allows the current system (action based subscriptions) to be implemented externally if the developer wants it, since it keeps calling callbacks with the `action` object.

So the library core keeps small and simple, while it can easily be incremented using wrappers, as long as it keeps providing the same information to the subscribers.