### PR TITLE
fix: ReducerStoreInterface should have the store name and getState pr…

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,6 +27,8 @@ declare module 'react-hookstore' {
   }
 
   export interface ReducerStoreInterface<TState, TPayload = any> {
+      readonly name: string;
+      getState(): TState;
       dispatch<TPayload>(payload: TPayload, callback?: StateCallback<TState>): void;
   }
 


### PR DESCRIPTION
fix: ReducerStoreInterface should have the store name and getState properties.

When you're using a reducer, you still have access to the store name and getState properties on the store instance. But this is currently not reflected in the typings.