### PR TITLE
react 16 to 18 to avoid peer deps error

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "webpack-merge": "^4.1.4"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^18.1.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
please update this to fix this error

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: client@0.0.0
npm ERR! Found: react@18.1.0
npm ERR! node_modules/react
npm ERR!   react@"^18.0.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.0" from react-hookstore@1.5.1
npm ERR! node_modules/react-hookstore
npm ERR!   react-hookstore@"^1.5.1" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/shivanan/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
```